### PR TITLE
Fix warning for elasticlunr user configuration parse

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,7 +137,7 @@ export default class Search extends Component {
             query,
             // Query the index with search string to get an [] of IDs
             results: this.index
-                .search(query)
+                .search(query, {})
                 // Map over each ID and return the full document
                 .map(({ ref }) => this.index.documentStore.getDoc(ref))
         });

--- a/example/src/components/search.js
+++ b/example/src/components/search.js
@@ -57,7 +57,7 @@ export default class Search extends Component {
             query,
             // Query the index with search string to get an [] of IDs
             results: this.index
-                .search(query)
+                .search(query, {})
                 // Map over each ID and return the full document
                 .map(({ ref }) => this.index.documentStore.getDoc(ref)),
         })


### PR DESCRIPTION
Supply an empty object as the user configuration in example script to suppress the following warning:

![image](https://user-images.githubusercontent.com/859780/47533990-c4de0480-d883-11e8-9fbd-89d61eb509cd.png)
