### PR TITLE
Pass getNode to custom resolver functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,4 +201,4 @@ reslovers : {
   }
 }
 ```
-Now you can use the `featuredImage` data of `BlogPost` model without including all `Asset` models in the `elasticlunr` index.
+Now you can use the `featuredImage` data of `BlogPost` model without including all `Asset` models in the `elasticlunr` index [(see PR #3 for more details)](https://github.com/gatsby-contrib/gatsby-plugin-elasticlunr-search/pull/3).

--- a/src/gatsby-node.js
+++ b/src/gatsby-node.js
@@ -65,7 +65,7 @@ const createOrGetIndex = async (
         ...Object.keys(fieldResolvers).reduce((prev, key) => {
           return {
             ...prev,
-            [key]: fieldResolvers[key](pageNode),
+            [key]: fieldResolvers[key](pageNode, getNode),
           }
         }, {}),
       }


### PR DESCRIPTION
Currently if you have a content model that has nested models (see `featuredImage` field below) you need to resolve all the nested models and then query the nested model in userland code to build a proper model with all the data you require. This makes the elasticlunr search index JSON potentially very large and the search logic more complicated ...
```
// gatsby-config.js
{
  resolve : '@gatsby-contrib/gatsby-plugin-elasticlunr-search-local',
  options : {
    // Blog article fields to index
    fields : [
      'title'
    ],
    // How to resolve each field's value for a supported node type
    resolvers : {
      // For any node of type ContentfulBlogPost, list how to resolve the fields' values
      ContentfulBlogPost : {
        title         : node => node.title,
        featuredImage : node => node.featuredImage___NODE
      },
      // For any node of type ContentfulAsset, this is how ContentfulBlogPost featuredImage is resolved
      ContentfulAsset : {
        fileUrl : node => node.file && node.file.url
      }
    }
  }
}
```
```
// search.js
....
...
searchIndex.search(query, { expand : true })
    .map(({ ref }) => {
      const { featuredImage, ...rest } = searchIndex.documentStore.getDoc(ref);
      let result = {
        ...rest
      };

      if (featuredImage) {
        const { fileUrl } = searchIndex.documentStore.getDoc(featuredImage) || {};
        result = {
          ...result,
          featuredImage : {
            fixed : {
              src : `${fileUrl}?w=300&h=200&q=50&fit=fill`
            }
          },
          retinaFeaturedImage : {
            fixed : {
              src : `${fileUrl}?w=600&h=400&q=50&fit=fill`
            }
          }
        };
      }

      return result;
    });
...
..
```
Imagine in the above scenario you have 1,000 `ContentfulBlogPost` models and 50,0000 `ContentfulAsset` models. The search index will contain 51,000 items when it really could contain 1,000 items that are a little larger given the nested `featuredImage` model.

This change passes the `getNode` function to all resolvers so that a user of this plugin can use the `getNode` function in there custom resolvers and avoid bloating there elasticlunr search index JSON...
```
{
  resolve : '@gatsby-contrib/gatsby-plugin-elasticlunr-search-local',
  options : {
    // Blog article fields to index
    fields : [
      'title'
    ],
    // How to resolve each field's value for a supported node type
    resolvers : {
      // For any node of type ContentfulBlogPost, list how to resolve the fields' values
      ContentfulBlogPost : {
        title         : node => node.title,
        featuredImage : (node, getNode) => getNode(node.featuredImage___NODE)
      }
    }
  }
}
```