### PR TITLE
Adding filter to onCreateNode to limit indexed values.

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,9 @@ module.exports = {
             path: node => node.frontmatter.path,
           },
         },
+        // Optional filter to limit indexed nodes
+        filter: (node, getNode) =>
+          node.frontmatter.tags !== 'exempt',
       },
     },
   ],

--- a/src/gatsby-node.js
+++ b/src/gatsby-node.js
@@ -102,10 +102,12 @@ exports.sourceNodes = async ({ getNodes, actions }) => {
   existingNodes.forEach(n => touchNode({ nodeId: n.id }))
 }
 
-exports.onCreateNode = ({ node, actions, getNode }, { resolvers }) => {
+exports.onCreateNode = ({ node, actions, getNode }, { resolvers, filter }) => {
   if (Object.keys(resolvers).indexOf(node.internal.type) === -1) {
     return
   }
+  
+  if (filter && !filter(node, getNode)) { return; }
 
   const { createNode } = actions
   const searchIndex = getNode(SEARCH_INDEX_ID) || createEmptySearchIndexNode()


### PR DESCRIPTION
This idea was originally proposed by pull request on the pre V2 version of gatsby-plugin-elasticlunr-search, but never merged. It allows for a filter option in gatsby-config.js to limit which nodes are indexed during the build process. It is super helpful if you want to limit search to certain content on the site.