### PR TITLE
get nodes by type

### DIFF
--- a/README.md
+++ b/README.md
@@ -205,3 +205,19 @@ resolvers : {
 }
 ```
 Now you can use the `featuredImage` data of `BlogPost` model without including all `Asset` models in the `elasticlunr` index [(see PR #3 for more details)](https://github.com/gatsby-contrib/gatsby-plugin-elasticlunr-search/pull/3).
+
+
+You can now also resolve the gatsby store with ``getNodesByType`` and ``getNodes``
+so the full signature of node resolving is this:
+```
+(node, getNode, getNodesByType, getNodes)
+```
+Documentation of all node helpers:
+
+- [getNode](https://www.gatsbyjs.org/docs/node-api-helpers/#getNode)
+- [getNodesByType](https://www.gatsbyjs.org/docs/node-api-helpers/#getNodesByType)
+- [getNodes](https://www.gatsbyjs.org/docs/node-api-helpers/#getNodes)
+
+
+
+

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@gatsby-contrib/gatsby-plugin-elasticlunr-search",
-  "version": "2.3.0",
+  "version": "2.4.0",
   "description": "Search for gatsby; implemented via elasticlunr.",
   "main": "n/a",
   "scripts": {

--- a/src/gatsby-node.js
+++ b/src/gatsby-node.js
@@ -41,6 +41,8 @@ const createOrGetIndex = async (
   node,
   cache,
   getNode,
+  getNodesByType, 
+  getNodes,
   server,
   { fields, resolvers }
 ) => {
@@ -65,7 +67,7 @@ const createOrGetIndex = async (
         ...Object.keys(fieldResolvers).reduce((prev, key) => {
           return {
             ...prev,
-            [key]: fieldResolvers[key](pageNode, getNode),
+            [key]: fieldResolvers[key](pageNode, getNode, getNodesByType, getNodes),
           }
         }, {}),
       }
@@ -116,7 +118,7 @@ exports.onCreateNode = ({ node, actions, getNode }, { resolvers, filter }) => {
 }
 
 exports.setFieldsOnGraphQLNodeType = (
-  { type, getNode, cache },
+  { type, getNode, getNodesByType, getNodes, cache },
   pluginOptions
 ) => {
   if (type.name !== SEARCH_INDEX_TYPE) {
@@ -127,7 +129,7 @@ exports.setFieldsOnGraphQLNodeType = (
     index: {
       type: SearchIndex,
       resolve: (node, _opts, _3, server) =>
-        createOrGetIndex(node, cache, getNode, server, pluginOptions),
+        createOrGetIndex(node, cache, getNode, getNodesByType, getNodes, server, pluginOptions),
     },
   }
 }


### PR DESCRIPTION
A small pr to expand getNode capabilities. This was a necessity for me when using sanity singletons, because there is no way to get the gatsby node ID, by getting a singleton by type is trivial.

This should be fully backwards compatible, so only bumping minor.

Gatsby source line reference I used to check if there was more APIs available(absolutely it is):

https://github.com/gatsbyjs/gatsby/blob/150da457b78c7682ff6c8c7e005c412f759705fa/packages/gatsby/src/utils/api-runner-node.js#L188